### PR TITLE
Fix wildcards in recorded headers

### DIFF
--- a/src/tape.ejs
+++ b/src/tape.ejs
@@ -4,7 +4,7 @@ var path = require("path");
  * <%- req.method %> <%- decodeURIComponent(req.path) %>
  *
 <% Object.keys(req._headers).forEach(function (key) { -%>
- * <%- key %>: <%- req._headers[key] %>
+ * <%- key %>: <%- req._headers[key].replace('/*', '/ *').replace('*/', '* /') %>
 <% }); -%>
  */
 


### PR DESCRIPTION
Prevents generating invalid JS syntax when a recorded header contains
wildcards (e.g `accept: */*`)