### PR TITLE
Adding support for TLS SNI connections

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -33,6 +33,7 @@ module.exports = function proxy(req, body, host) {
       path:     req.url,
       headers:  req.headers,
 
+      servername: uri.hostname,
       rejectUnauthorized: false
     }, function (pres) {
       resolve(pres);


### PR DESCRIPTION
This PR adds support for websites using TLS Server Name Indication. 
Requests on SNI enabled websites (e.g. https://wiki.apache.org) results in a 400 Bad request. Adding `servername` with the correct hostname to the request options solves this issue. See <https://nodejs.org/docs/latest/api/https.html#https_https_request_options_callback>