### PR TITLE
add simpleTapeName yakbak option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [2.6.0] - 2016-09-15
+
+### Added
+
+- `simpleTapeName` option only includes `req.method` + `req.url` in `tapename`.
+
 ## [2.5.0] - 2016-06-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ var handler = yakbak('http://api.flickr.com', {
 
 - `dirname` the path where recorded responses will be written (required).
 - `noRecord` if true, requests will return a 404 error if the tape doesn't exist
+- `simpleTapeName` if true only includes `req.method` + `req.url` in `tapename`
 
 ### with node's http module
 

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ var debug = require('debug')('yakbak:server');
  * @param {Object} opts
  * @param {String} opts.dirname The tapes directory
  * @param {Boolean} opts.noRecord if true, requests will return a 404 error if the tape doesn't exist
+ * @param {Boolean} opts.simpleTapeName if true only includes `req.method` + `req.url` in `tapename`
  * @returns {Function}
  */
 
@@ -30,7 +31,7 @@ module.exports = function (host, opts) {
     debug('req', req.url);
 
     return buffer(req).then(function (body) {
-      var file = path.join(opts.dirname, tapename(req, body));
+      var file = path.join(opts.dirname, tapename(req, body, opts.simpleTapeName));
 
       return Promise.try(function () {
         return require.resolve(file);
@@ -69,8 +70,13 @@ module.exports = function (host, opts) {
  * @returns {String}
  */
 
-function tapename(req, body) {
-  return hash.sync(req, Buffer.concat(body)) + '.js';
+function tapename(req, body, simple = false) {
+  if (simple) {
+    return `${req.method}${req.url.replace(/\//g, '_')}.js`;
+  } else {
+    console.log(hash.sync(req, Buffer.concat(body)) + '.js');
+    return hash.sync(req, Buffer.concat(body)) + '.js';
+  }
 }
 
 /**

--- a/test/yakbak.js
+++ b/test/yakbak.js
@@ -62,6 +62,26 @@ describe('yakbak', function () {
           done();
         });
       });
+
+      describe('when simpleTapeName = true', function () {
+        beforeEach(function () {
+          yakbak = subject(server.host, { dirname: tmpdir.dirname, simpleTapeName: true });
+        });
+
+        it('can write to disk with a descriptive filename', function(done) {
+          request(yakbak)
+          .get('/record/2')
+          .set('host', 'localhost:3001')
+          .expect('X-Yakbak-Tape', 'GET_record_2')
+          .expect('Content-Type', 'text/html')
+          .expect(201, 'OK')
+          .end(function (err) {
+            assert.ifError(err);
+            assert(fs.existsSync(tmpdir.join('GET_record_2.js')));
+            done();
+          });
+        });
+      });
     });
 
     describe("when recording is not enabled", function () {


### PR DESCRIPTION
My response headers always include stuff like timestamps and new access tokens.

For testing such APIs I wish the tapename resolutions were simpler.

This enables that with the `simpleTapeName` option.
