### PR TITLE
Added new Option to configure yakbak to record only successful requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ var handler = yakbak('http://api.flickr.com', {
 
 - `dirname` the path where recorded responses will be written (required).
 - `noRecord` if true, requests will return a 404 error if the tape doesn't exist
+- `recordOnlySuccess` if true, only successful requests (response status code = 2XX) will be recorded
 - `hash(req, body)` provide your own IncomingMessage hash function
 
 ### with node's http module

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ module.exports = function (host, opts) {
       return tape(req, res);
     }).catch(RecordingDisabledError, function (err) {
       /* eslint-disable no-console */
-      console.log('An HTTP request has been made that yakbak does not know how to handle');
+      console.log(err.message);
       console.log(curl.request(req));
       /* eslint-enable no-console */
       res.statusCode = err.status;

--- a/index.js
+++ b/index.js
@@ -97,8 +97,7 @@ function ModuleNotFoundError(err) {
 
 /**
  * Error class that is thrown when an unmatched request
- * is encountered in noRecord mode or when recordOnlySuccess is enabled
- * and the request failed
+ * is encountered in noRecord mode or when a request failed in recordOnlySuccess mode
  * @constructor
  */
 

--- a/index.js
+++ b/index.js
@@ -42,18 +42,13 @@ module.exports = function (host, opts) {
           throw new RecordingDisabledError('Recording Disabled');
         } else {
           return proxy(req, body, host).then(function (pres) {
-            console.log('Am i here', opts); // eslint-disable-line
             if (opts.recordOnlySuccess === true) {
-              console.log('Am i here-1', opts, pres.statusCode); // eslint-disable-line
                 if (successfulResponse.test(pres.statusCode)) {
-                  console.log('Am i here-2', opts); // eslint-disable-line
                    return record(pres.req, pres, file);
                 } else {
-                  console.log('Am i here-3', opts); // eslint-disable-line
                   throw new RecordingDisabledError('Only Successful responses will be recorded');
                 }
             } else {
-              console.log('Am i here-4', opts); // eslint-disable-line
               return record(pres.req, pres, file);
             }
           });

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -24,7 +24,6 @@ var mods = { 'http:': http, 'https:': https };
 
 module.exports = function proxy(req, body, host) {
   return new Promise(function (resolve /* , reject */) {
-    console.log('Request host:', host);
     var uri = url.parse(host);
     var mod = mods[uri.protocol] || http;
     var preq = mod.request({

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -24,6 +24,7 @@ var mods = { 'http:': http, 'https:': https };
 
 module.exports = function proxy(req, body, host) {
   return new Promise(function (resolve /* , reject */) {
+    console.log('Request host:', host);
     var uri = url.parse(host);
     var mod = mods[uri.protocol] || http;
     var preq = mod.request({

--- a/test/helpers/server.js
+++ b/test/helpers/server.js
@@ -6,13 +6,14 @@ var http = require('http');
 /**
  * Creates a test HTTP server.
  * @param {Function} done
+ * @param {boolean} errorResponse - Specifies whether response has to be error or not
  * @returns {http.Server}
  */
 
-module.exports = function createServer(cb) {
-
+module.exports = function createServer(cb, errorResponse) {
+  console.log('In create server:', cb, errorResponse);
   var server = http.createServer(function (req, res) {
-    res.statusCode = 201;
+    res.statusCode = errorResponse === true ? 404 : 201;
 
     res.setHeader('Content-Type', 'text/html');
     res.setHeader('Date', 'Sat, 26 Oct 1985 08:20:00 GMT');

--- a/test/helpers/server.js
+++ b/test/helpers/server.js
@@ -6,14 +6,13 @@ var http = require('http');
 /**
  * Creates a test HTTP server.
  * @param {Function} done
- * @param {boolean} errorResponse - Specifies whether response has to be error or not
+ * @param {boolean} failRequest - Specifies whether response has to be error or not
  * @returns {http.Server}
  */
 
-module.exports = function createServer(cb, errorResponse) {
-  console.log('In create server:', cb, errorResponse);
+module.exports = function createServer(cb, failRequest) {
   var server = http.createServer(function (req, res) {
-    res.statusCode = errorResponse === true ? 404 : 201;
+    res.statusCode = failRequest === true ? 404 : 201;
 
     res.setHeader('Content-Type', 'text/html');
     res.setHeader('Date', 'Sat, 26 Oct 1985 08:20:00 GMT');

--- a/test/yakbak.js
+++ b/test/yakbak.js
@@ -12,7 +12,6 @@ var fs = require('fs');
 var crypto = require('crypto');
 var url = require('url');
 
-/* eslint-dsiable*/
 describe('yakbak', function () {
   var server, tmpdir, yakbak;
 
@@ -25,12 +24,10 @@ describe('yakbak', function () {
   });
 
   beforeEach(function (done) {
-    console.log('Create dir');
     tmpdir = createTmpdir(done);
   });
 
   afterEach(function (done) {
-    console.log('director deletio dir');
     tmpdir.teardown(done);
   });
 
@@ -140,18 +137,20 @@ describe('yakbak', function () {
     });
 
     describe.only("when onlySuccessResponse is enabled", function () {
-      beforeEach(function () {
+      beforeEach(function (done) {
+        // server.teardown(done);
+        server = createServer(done, true);
         yakbak = subject(server.host, { dirname: tmpdir.dirname, recordOnlySuccess: true });
       });
 
-      it('does not write the tape to disk', function (done) {
+      it('does not write the tape to disk if response statusCode is not 2XX', function (done) {
         request(yakbak)
-        .get('/blahblah/2')
-        .set('host', 'localhost:4001')
+        .get('/record/2')
+        .set('host', 'localhost:3001')
         .expect(404)
         .end(function (err) {
-          console.log('I am in end error', tmpdir.dirname, err); // eslint-disable-line
-         // assert(!fs.existsSync(tmpdir.join('3234ee470c8605a1837e08f218494326.js')));
+          assert.ifError(err);
+          assert(!fs.existsSync(tmpdir.join('3234ee470c8605a1837e08f218494326.js')));
           done();
         });
       });

--- a/test/yakbak.js
+++ b/test/yakbak.js
@@ -12,6 +12,7 @@ var fs = require('fs');
 var crypto = require('crypto');
 var url = require('url');
 
+/* eslint-dsiable*/
 describe('yakbak', function () {
   var server, tmpdir, yakbak;
 
@@ -24,10 +25,12 @@ describe('yakbak', function () {
   });
 
   beforeEach(function (done) {
+    console.log('Create dir');
     tmpdir = createTmpdir(done);
   });
 
   afterEach(function (done) {
+    console.log('director deletio dir');
     tmpdir.teardown(done);
   });
 
@@ -131,6 +134,24 @@ describe('yakbak', function () {
         .end(function (err) {
           assert.ifError(err);
           assert(!fs.existsSync(tmpdir.join('3234ee470c8605a1837e08f218494326.js')));
+          done();
+        });
+      });
+    });
+
+    describe.only("when onlySuccessResponse is enabled", function () {
+      beforeEach(function () {
+        yakbak = subject(server.host, { dirname: tmpdir.dirname, recordOnlySuccess: true });
+      });
+
+      it('does not write the tape to disk', function (done) {
+        request(yakbak)
+        .get('/blahblah/2')
+        .set('host', 'localhost:4001')
+        .expect(404)
+        .end(function (err) {
+          console.log('I am in end error', tmpdir.dirname, err); // eslint-disable-line
+         // assert(!fs.existsSync(tmpdir.join('3234ee470c8605a1837e08f218494326.js')));
           done();
         });
       });

--- a/test/yakbak.js
+++ b/test/yakbak.js
@@ -136,10 +136,19 @@ describe('yakbak', function () {
       });
     });
 
-    describe.only("when onlySuccessResponse is enabled", function () {
+    describe("when onlySuccessResponse is enabled", function () {
       beforeEach(function (done) {
-        // server.teardown(done);
+         /* tear down the server created in global scope as we
+         need different server object which can send response with failed status code*/
+        server.teardown(done);
+      });
+
+      beforeEach(function (done) {
+        /* Send the failed response for the requests this server handles */
         server = createServer(done, true);
+      });
+
+      beforeEach(function () {
         yakbak = subject(server.host, { dirname: tmpdir.dirname, recordOnlySuccess: true });
       });
 


### PR DESCRIPTION
Hello Guys,

We are using **Yakbak** to facilitate faster responses in our **_development_** environment.

Some of you might have faced this situation, sometimes the backend api may not be fully functional in dev environments and as a result the requests will fail. Once we change the backend api to send correct response, we always have to delete our existing tape because the error was already recorded for that request. (Its an inconvenience to find the exact tape and delete, so we end up deleting entire tapes folder)

So to address that situation, I added this new option which helps configuring yakbak to record responses only for the successful requests.

I hope you will accept this feature and make yakbak more awesome.

Thanks,
Ram
