### PR TITLE
fix(comment-escaping): Escape comment delimiters in `req.path` 

### DIFF
--- a/src/tape.ejs
+++ b/src/tape.ejs
@@ -1,10 +1,14 @@
 var path = require("path");
 
+<% function escapeComments(str) {
+  return str.split('/*').join('/ *').split('*/').join('* /')
+} %>
+
 /**
- * <%- req.method %> <%- decodeURIComponent(req.path) %>
+ * <%- req.method %> <%- escapeComments(decodeURIComponent(req.path)) %>
  *
 <% Object.keys(req._headers).forEach(function (key) { -%>
- * <%- key %>: <%- req._headers[key].replace('/*', '/ *').replace('*/', '* /') %>
+ * <%- key %>: <%- escapeComments(req._headers[key]) %>
 <% }); -%>
  */
 


### PR DESCRIPTION
(and occurring multiply)

Currently a `req.path` containing */ (* is a valid URL character)
will on recording terminate the headers' comment, leaving a broken tape.
Similarly if a /* or */ occurs more than once the additional sequences
are not escaped.